### PR TITLE
Adding aws_eks_openid_idp module

### DIFF
--- a/aws_eks_openid_idp/main.tf
+++ b/aws_eks_openid_idp/main.tf
@@ -1,0 +1,13 @@
+data "aws_eks_cluster" "cluster" {
+  name = var.cluster_name
+}
+
+data "tls_certificate" "certificate" {
+  url = data.aws_eks_cluster.cluster.identity[0].oidc[0].issuer
+}
+
+resource "aws_iam_openid_connect_provider" "this" {
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = [data.tls_certificate.certificate.certificates[0].sha1_fingerprint]
+  url             = data.aws_eks_cluster.cluster.identity[0].oidc[0].issuer
+}

--- a/aws_eks_openid_idp/outputs.tf
+++ b/aws_eks_openid_idp/outputs.tf
@@ -1,0 +1,11 @@
+output "id" {
+  value = aws_iam_openid_connect_provider.this.id
+}
+
+output "arn" {
+  value = aws_iam_openid_connect_provider.this.arn
+}
+
+output "url" {
+  value = aws_iam_openid_connect_provider.this.url
+}

--- a/aws_eks_openid_idp/variables.tf
+++ b/aws_eks_openid_idp/variables.tf
@@ -1,0 +1,4 @@
+variable "cluster_name" {
+  type = string
+  description = "The name of the EKS cluster for which we want to create the OpenID IDP."
+}


### PR DESCRIPTION
Module for creating OpenID IDP on an EKS cluster.
Required for allowing EKS service accounts to assume AWS roles for interacting with AWS objects (like Route53 zones).